### PR TITLE
Run coverage on ubuntu rather than macOS

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -12,7 +12,7 @@ name: test-coverage
 
 jobs:
   test-coverage:
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
running on macOS causes a conflict between the default gfortran and clang toolchains, as the coverage format differs between them.

Running on ubuntu uses gcc everywhere, so should avoid the issue.